### PR TITLE
Add FigurePager for single-figure navigation of explanations

### DIFF
--- a/examples/example_titanic_v2.py
+++ b/examples/example_titanic_v2.py
@@ -15,8 +15,8 @@ from hermai.explainers import LocalExplainer, GeneralExplainer # <-- Daha temiz 
 # --- 1. Data Loading and Preparation ---
 print("🚢 1. Loading and preparing the Titanic dataset...")
 df = sns.load_dataset('titanic').drop(['deck', 'embark_town', 'alive', 'who', 'adult_male', 'alone', 'class'], axis=1)
-df['age'].fillna(df['age'].median(), inplace=True)
-df['embarked'].fillna(df['embarked'].mode()[0], inplace=True)
+df['age'] = df['age'].fillna(df['age'].median())
+df['embarked'] = df['embarked'].fillna(df['embarked'].mode()[0])
 df.dropna(inplace=True)
 df['sex'] = LabelEncoder().fit_transform(df['sex'])
 df['embarked'] = LabelEncoder().fit_transform(df['embarked'])

--- a/examples/example_titanic_v2.py
+++ b/examples/example_titanic_v2.py
@@ -11,6 +11,7 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from hermai.perturbations.tabular import TabularPerturbationGenerator
 from hermai.explainers import LocalExplainer, GeneralExplainer # <-- Daha temiz import
+from hermai.visualizations.navigator import show_explanations_pager
 
 # --- 1. Data Loading and Preparation ---
 print("🚢 1. Loading and preparing the Titanic dataset...")
@@ -41,22 +42,15 @@ print(instance)
 local_explanation = local_explainer.explain(instance)
 print("\n--- Explanation Narrative ---")
 print(local_explanation.narrative())
-print("\n--- Feature Contribution Plot ---")
-local_explanation.plot()
 
-# --- 4. GENERAL MODEL EXPLANATION ---  <-- DEĞİŞTİ
+# --- 4. GENERAL MODEL EXPLANATION ---  
 print("\n\n" + "="*50)
-print("🌍 4. GENERATING GENERAL MODEL EXPLANATION") # <-- DEĞİŞTİ
+print("🌍 4. GENERATING GENERAL MODEL EXPLANATION") 
 print("="*50)
 # Setup the general explainer
-general_explainer = GeneralExplainer(black_box_model) # <-- DEĞİŞTİ
+general_explainer = GeneralExplainer(black_box_model)
 
 # Explain the model's overall behavior using the training data
-general_explanation = general_explainer.explain(X_train) # <-- DEĞİŞTİ
+general_explanation = general_explainer.explain(X_train) 
 
-# Show general importance and the decision tree approximation
-print("\n--- General Feature Importance Plot ---") # <-- DEĞİŞTİ
-general_explanation.plot_feature_importance()
-print("\n--- Approximated Decision Rules (Surrogate Tree) ---")
-print("This tree shows the main decision paths the complex RandomForest model appears to follow.")
-general_explanation.plot_surrogate_tree()
+show_explanations_pager(local_explanation, general_explanation)

--- a/hermai/visualizations/navigator.py
+++ b/hermai/visualizations/navigator.py
@@ -1,0 +1,58 @@
+import matplotlib.pyplot as plt
+from matplotlib.widgets import Button
+from . import plots
+
+class FigurePager:
+    def __init__(self, pages, titles):
+        self.pages = pages
+        self.titles = titles
+        self.idx = 0
+
+        self.fig = plt.figure(figsize=(14, 8))
+        
+        self.plot_box = [0.07, 0.18, 0.86, 0.74]   # left, bottom, width, height
+        self.ax = self.fig.add_axes(self.plot_box)
+
+        self._add_buttons()
+        self._draw()
+
+    def _add_buttons(self):
+        ax_prev = self.fig.add_axes([0.30, 0.06, 0.15, 0.05])
+        ax_next = self.fig.add_axes([0.55, 0.06, 0.15, 0.05])
+        self.b_prev = Button(ax_prev, "<--- Back")
+        self.b_next = Button(ax_next, "Next --->")
+        self.b_prev.on_clicked(lambda _e: self._update(-1))
+        self.b_next.on_clicked(lambda _e: self._update(+1))
+
+    def _draw(self):
+        self.ax.remove()
+        self.ax = self.fig.add_axes(self.plot_box)
+
+        self.pages[self.idx](self.ax)
+
+        self.ax.set_title("")
+        self.fig.suptitle(self.titles[self.idx], y=0.97)
+
+        self.fig.canvas.draw_idle()
+
+    def _update(self, delta):
+        self.idx = (self.idx + delta) % len(self.pages)
+        self._draw()
+
+def show_explanations_pager(local_exp, general_exp):
+    def draw_local(ax):
+        plots.plot_local_feature_importance(local_exp, ax=ax, show=False)
+
+    def draw_global(ax):
+        plots.plot_general_feature_importance(general_exp, ax=ax, show=False)
+
+    def draw_tree(ax):
+        plots.plot_surrogate_tree(general_exp, ax=ax, show=False)
+
+    FigurePager(
+        pages=[draw_local, draw_global, draw_tree],
+        titles=["Local Feature Importance",
+                "General Feature Importance (from Surrogate Model)",
+                "Surrogate Decision Tree"]
+    )
+    plt.show()

--- a/hermai/visualizations/plots.py
+++ b/hermai/visualizations/plots.py
@@ -20,7 +20,8 @@ def plot_local_feature_importance(explanation):
 def plot_general_feature_importance(explanation): # <-- DEĞİŞTİ
     """Plots a bar chart for general feature importances."""
     plt.figure(figsize=(10, 8))
-    sns.barplot(x='importance', y='feature', data=explanation.feature_importances.head(15), palette='viridis')
+    sns.barplot(x='importance', y='feature', data=explanation.feature_importances.head(15), palette='viridis',
+                hue='feature', legend=False, dodge=False)
     plt.xlabel("Feature Importance (Gini)")
     plt.ylabel("Feature")
     plt.title("General Feature Importance (from Surrogate Model)") # <-- DEĞİŞTİ

--- a/hermai/visualizations/plots.py
+++ b/hermai/visualizations/plots.py
@@ -3,34 +3,38 @@ import matplotlib.pyplot as plt
 import seaborn as sns
 from sklearn.tree import plot_tree
 
-def plot_local_feature_importance(explanation):
-    # ... (Bu fonksiyonda değişiklik yok) ...
+def plot_local_feature_importance(explanation, ax=None, show=True):
     top_features = explanation.feature_importances.head(10)
     top_features = top_features[top_features['importance'].abs() > 1e-6]
     top_features = top_features.sort_values(by='importance', ascending=True)
-
-    plt.figure(figsize=(10, 6))
+    if ax is None:
+        fig, ax = plt.subplots(figsize=(10, 6), constrained_layout=True)
     colors = ['#d65f5f' if x < 0 else '#5f8ad6' for x in top_features['importance']]
-    plt.barh(top_features['feature'], top_features['importance'], color=colors)
-    plt.xlabel("Contribution to Prediction Probability")
-    plt.title("Local Feature Importance")
-    plt.tight_layout()
-    plt.show()
-
-def plot_general_feature_importance(explanation): # <-- DEĞİŞTİ
-    """Plots a bar chart for general feature importances."""
-    plt.figure(figsize=(10, 8))
-    sns.barplot(x='importance', y='feature', data=explanation.feature_importances.head(15), palette='viridis',
-                hue='feature', legend=False, dodge=False)
-    plt.xlabel("Feature Importance (Gini)")
-    plt.ylabel("Feature")
-    plt.title("General Feature Importance (from Surrogate Model)") # <-- DEĞİŞTİ
-    plt.tight_layout()
-    plt.show()
+    ax.barh(top_features['feature'], top_features['importance'], color=colors)
+    ax.set_xlabel("Contribution to Prediction Probability")
+    ax.set_title("Local Feature Importance")
     
-def plot_surrogate_tree(explanation):
-    # ... (Bu fonksiyonda değişiklik yok) ...
-    plt.figure(figsize=(20, 10))
+    if show:
+        plt.tight_layout()
+        plt.show()
+
+def plot_general_feature_importance(explanation, ax=None, show=True):
+    """Plots a bar chart for general feature importances."""
+    if ax is None:
+        fig, ax = plt.subplots(figsize=(10, 8), constrained_layout=True)
+    sns.barplot(x='importance', y='feature', data=explanation.feature_importances.head(15), palette='viridis',
+                hue='feature', legend=False, dodge=False, ax=ax)
+    ax.set_xlabel("Feature Importance (Gini)")
+    ax.set_ylabel("Feature")
+    ax.set_title("General Feature Importance (from Surrogate Model)")
+
+    if show:
+        plt.tight_layout()
+        plt.show()
+
+def plot_surrogate_tree(explanation, ax=None, show=True):
+    if ax is None:
+        fig, ax = plt.subplots(figsize=(20, 10))
     plot_tree(
         explanation.surrogate_model,
         feature_names=explanation.feature_importances['feature'].tolist(),
@@ -39,5 +43,7 @@ def plot_surrogate_tree(explanation):
         rounded=True,
         fontsize=10
     )
-    plt.title("Surrogate Decision Tree Approximating the Model")
-    plt.show()
+    ax.set_title("Surrogate Decision Tree Approximating the Model")
+    if show:
+        plt.tight_layout()
+        plt.show()


### PR DESCRIPTION
# Describe Changes
- Added new file 'hermai/visualizations/navigator.py'.
-  With the 'FigurePager' class all visualizations can be navigated within a single figure with forward/backward buttons.
- All graphs can be navigated within a single figure.
- Added `plots.py` functions accept 'ax' parameter.

# Issue ticket number and link
Closes #3 - [Feature Request: Displaying all graphics in a single figure](https://github.com/BilgisayarKavramlari/hermai/issues/3)